### PR TITLE
A few more technical fixes

### DIFF
--- a/PhotDM.tex
+++ b/PhotDM.tex
@@ -182,8 +182,8 @@ combine that data in a scientifically meaningful way. A Spectral
 Energy Distribution (SED) is an example of combining data whereby 
 flux density measurements of an astrophysical source at different 
 spectral energy coordinates (wavelengths/frequencies/energy)
-(\citep{doi:10.1146/annurev.astro.41.082801.100251}, 
-\citep{longo}, \citep{connell}, \citep{brujine}) are plotted as a 
+\citep{doi:10.1146/annurev.astro.41.082801.100251,longo,connell,brujine}
+are plotted as a 
 graph of flux density versus a spectral energy coordinate. SEDs that 
 cover a wide range of the electromagnetic spectrum are particularly 
 useful for identifying the underlying physical processes operating 
@@ -397,9 +397,9 @@ Figure 3.1 of the Synphot manual:
 For a photometric system that uses Vega magnitudes, the zero point 
 flux for each filter is the average flux density of Vega over that 
 bandpass $f_{Vega}$. Some typical values of $f_{Vega}$ are tabulated in 
-(\citep{2001eaa..book.....M}) for the Johnson photometric system. Although 
+\citep{2001eaa..book.....M} for the Johnson photometric system. Although 
 the agreed Vega spectrum has changed historically, the commonly referred to 
-spectrum of Vega in digital form described in (\citep{2004AJ....127.3508B}) 
+spectrum of Vega in digital form described in \citep{2004AJ....127.3508B} 
 is available as file at \emph{alpha\_lyr\_stis\_002.fits} at:\par
 \url{http://www.stsci.edu/instruments/observatory/cdbs/calspec}
 \par
@@ -633,7 +633,7 @@ photometry filter properties.
 \par
 
 This identifier follows the IVOA syntax defined for IVOA 
-identifiers (\citep{2016ivoa.spec.0523D}) which gives a string built up as:
+identifiers \citep{2016ivoa.spec.0523D} which gives a string built up as:
 \par
 
 %%%%%%%%%%%%%%%%%%%% Table No: 6 starts here %%%%%%%%%%%%%%%%%%%%
@@ -773,10 +773,10 @@ with $\lambda < 4000 \angstrom $ or  $\lambda > 7000 \angstrom $.
 \par
 
 This curve can be used, e.g. for the creation of synthetic photometry 
-(\citep{1996BaltA...5..459S},\citep{2004A&A...422..205G}) from an observational 
+\citep{1996BaltA...5..459S,2004A&A...422..205G} from an observational 
 or a theoretical spectrum by applying it to the spectrum in the filter band-pass. 
 Taking as input a certain flux, the effective flux as seen using a certain 
-filter would be, for energy counters (\citep{2007ASPC..364..227M}):
+filter would be, for energy counters \citep{2007ASPC..364..227M}:
 
 \begin{equation} \label{eq:14}
 f(\lambda_{eff}) = \frac{\int T(\lambda)F(\lambda)d\lambda}{\int T(\lambda)d\lambda}
@@ -810,7 +810,7 @@ A spectral coordinate value that can be considered by the data provider as the
 most representative for this specific filter band-pass. The selection of this 
 value should take into account the filter transmission curve profile and in 
 general should be close to the wavelength mean value, defined 
-(\citep{1982AJ.....87..670O}) as:
+in \citet{1982AJ.....87..670O} as:
 \par
 \begin{equation} \label{eq:16}
 \lambda_{mean} = \frac{\int T(\lambda)\lambda d\lambda}{\int T(\lambda)d\lambda}
@@ -866,8 +866,8 @@ data fields as shown above. See serialization example in section
 
 \paragraph{PhotometryFilter.transmissionCurve.access}
 If the transmission curve is hooked as an external file, we use the \textit{Access} class 
-defined in the Observation Core Components data model (\citep{2017ivoa.spec.0509L}) and inherited 
-from the SSA specification (\citep{2012ivoatody}).
+defined in the Observation Core Components data model \citep{2017ivoa.spec.0509L} and inherited 
+from the SSA specification \citep{2012ivoatody}.
 \par
 
 \subparagraph{PhotometryFilter.transmissionCurve.access.reference} 
@@ -930,7 +930,7 @@ transmissionPoint.transmissionValu}e}\par}
 \subparagraph{PhotometryFilter.transmissionCurve.transmissionPoint.
 spectralValue.UCD: String}
 This data model field contains a Unified Content Description string (UCD) 
-(\citep{2018ivoa.spec.0527P}) that specifies the nature of the spectral axis for this filter. 
+\citep{2018ivoa.spec.0527P} that specifies the nature of the spectral axis for this filter. 
 This applies to the full spectral axis description of the filter.
 \par
 
@@ -1120,7 +1120,7 @@ Magnitude error is a dimensionless variable.\par
 Usual definition of magnitudes, also called Pogson magnitudes, can be improved 
 for faint sources by replacing the usual logarithm with an inverse hyperbolic 
 sine function. These kinds of magnitudes are called $``$asinh magnitudes$"$  
-or $``$luptitudes$"$  (\citep{2004A&A...422..205G})\par
+or $``$luptitudes$"$  \citep{2004A&A...422..205G}.\par
 
 %%%%%%%%%%%%%%%%%%%% Table No: 17 starts here %%%%%%%%%%%%%%%%%%%%
 
@@ -1226,7 +1226,7 @@ Extension of ZeroPoint  to describe asinh magnitudes, a.k.a. luptitudes.
 
 \subsubsection{AsinhZeroPoint.softeningParameter: real}
 Parameter used to correct the calculation of magnitudes for faint 
-sources. Usually called b. See (\citep{1999AJ....118.1406L}) for 
+sources. Usually called b. See \citep{1999AJ....118.1406L} for 
 a formal explanation.
 \par
 
@@ -2017,7 +2017,6 @@ of the softening parameter attached to the Asinh case.
     language=xml,
     tabsize=3,
     frame=lines,
-    label=code:sample,
     %frame=shadowbox,
     rulesepcolor=\color{gray},
     xleftmargin=20pt,

--- a/PhotDM.tex
+++ b/PhotDM.tex
@@ -16,6 +16,14 @@
 \usepackage[font=footnotesize,labelfont=bf]{caption}
 \usepackage{titlesec}
 
+\setcounter{secnumdepth}{6}
+\titleformat{\paragraph}{\normalfont\normalsize\sffamily\bfseries}
+  {\theparagraph}{1ex}{}
+\titlespacing*{\paragraph}{0pt}{6pt plus 4pt}{4pt}
+\titleformat{\subparagraph}{\normalfont\normalsize\sffamily\itshape}
+  {\thesubparagraph}{1ex}{}
+\titlespacing*{\subparagraph}{0pt}{4pt plus 2pt}{4pt}
+
 \usepackage[utf8]{inputenc}
 \usepackage{float}
 \usepackage[titletoc]{appendix}
@@ -856,18 +864,18 @@ This data model field stores points of the curve in place in a simple table usin
 data fields as shown above. See serialization example in section 
 \ref{serializationfilter} \par
 
-\paragraph{3.2.9.1 PhotometryFilter.transmissionCurve.access} \hspace{0pt} \\
+\paragraph{PhotometryFilter.transmissionCurve.access}
 If the transmission curve is hooked as an external file, we use the \textit{Access} class 
 defined in the Observation Core Components data model (\citep{2017ivoa.spec.0509L}) and inherited 
 from the SSA specification (\citep{2012ivoatody}).
 \par
 
-\subparagraph{3.2.9.1.1 PhotometryFilter.transmissionCurve.access.reference} 
-\hspace{0pt} \\
+\subparagraph{PhotometryFilter.transmissionCurve.access.reference} 
+
 The access reference is a URI (typically a URL) which can be used to retrieve the 
 specific dataset described in a row of the query table response. \par
 
-\subparagraph{3.2.9.1.2 PhotometryFilter.transmissionCurve.access.format} \hspace{0pt} \\
+\subparagraph{PhotometryFilter.transmissionCurve.access.format}
 The PhotometryFilter.transmissionCurve.access.format data model field tells the MIME 
 type of the file pointed to and used to store the curve points. Values for this 
 string can generally be:\par
@@ -888,15 +896,13 @@ $``$Spectrum1.1$"$  for instance, and all necessary fields for the spectral and
 flux coordinates.
 \par
 
-\subparagraph{3.2.9.1.3 PhotometryFilter.transmissionCurve.access.size} 
-\hspace{0pt} \\
+\subparagraph{PhotometryFilter.transmissionCurve.access.size} 
 Approximate estimated size of the dataset, specified in kilobytes. This would 
 help the client estimate download times and storage requirements when generating 
 execution plans. Only an approximate, order of magnitude value is required (a value 
 rounded up to the nearest hundred kB would be sufficient).\par
 
-\paragraph{3.2.9.2 PhotometryFilter.transmissionCurve.transmissionPoint} 
-\hspace{0pt} \\
+\paragraph{PhotometryFilter.transmissionCurve.transmissionPoint} 
 The transmission curve is a mathematical function that describes the transmission 
 fraction of a certain filter in a defined spectral range. This function can be discretised 
 as a set of transmission points and every point will be composed by two attributes:
@@ -921,9 +927,8 @@ transmissionPoint.spectralValue}}\par}
 transmissionPoint.transmissionValu}e}\par}
 \end{center}\par
 
-\subparagraph{3.2.9.2.1
-PhotometryFilter.transmissionCurve.transmissionPoint.
-spectralValue.UCD: String} \hspace{0pt} \\
+\subparagraph{PhotometryFilter.transmissionCurve.transmissionPoint.
+spectralValue.UCD: String}
 This data model field contains a Unified Content Description string (UCD) 
 (\citep{2018ivoa.spec.0527P}) that specifies the nature of the spectral axis for this filter. 
 This applies to the full spectral axis description of the filter.
@@ -954,40 +959,36 @@ Although this will partially reuse the
 Char.SpectralAxis.Coverage.Location.Bounds
 \end{center}\par
 
-concept of the Characterization Data Model, the basic elements of this object are described 
+\noindent concept of the Characterization Data Model, 
+the basic elements of this object are described 
 within the context of a photometry filter as follows.
 \par
 
-\paragraph{3.2.10.1
-PhotometryFilter.bandwith.UCD: String} \hspace{0pt} \\
+\paragraph{PhotometryFilter.bandwith.UCD: String}
 Unified Content Description (UCD) string that specifies the nature of the bandwidth object.
 \par
 
-\paragraph{3.2.10.2
-PhotometryFilter.bandwith.unit: IVOA.Unit} \hspace{0pt} \\
+\paragraph{PhotometryFilter.bandwith.unit: IVOA.Unit}
 Field that specifies the units of the bandwidth object.
 \par
 
-\paragraph{3.2.10.3
-PhotometryFilter.bandwith.extent: real} \hspace{0pt} \\
+\paragraph{PhotometryFilter.bandwith.extent: real}
 For square filters (100$\%$  between the minimum and maximum wavelength and 0$\%$  otherwise), 
 the bandwidth could be described as $\lambda_{max} - \lambda_{min}$.
 \par
 
 However, for real filters, the bandwidth is not very usable to describe the band-pass of the 
-filter, but the effective width, that can be described as follow:
+filter, but the effective width, that can be described as follows:
 \begin{equation} \label{eq:21}
 w = \frac{\int T(\lambda)d\lambda}{Max(T(\lambda))}
 \end{equation}
-
 where $w$ is the effective width, $T(\lambda)$ is the transmission curve (see below) 
 and $Max(T(\lambda))$ the maximum value of the transmission curve. As in previous points, 
 please notice that, since the transmission curve will be only defined in a specific spectral 
 range, the integrals will also be defined in this spectral range.
 \par
 
-\paragraph{3.2.10.4
-PhotometryFilter.bandwith.start: real } \hspace{0pt} \\
+\paragraph{PhotometryFilter.bandwith.start: real}
 %mir suggestion from MCD review
 Also called $\lambda_{min}$ in the rest of the document, this is a spectral value that better describes 
 the reasonable minimum value of the spectral range of the filter band-pass. In general,
@@ -1002,8 +1003,7 @@ transmission curves, this quantity will be close to:
 In practice, this could be taken as the minimum value of the filter transmission curve.
 \par
 
-\paragraph{3.2.10.5
-PhotometryFilter.bandwith.stop: real} \hspace{0pt} \\
+\paragraph{PhotometryFilter.bandwith.stop: real}
 Also called $\lambda_{max}$ in the rest of the document, this is a spectral value that 
 better describes the reasonable maximum value of the spectral range of the filter band-pass. 
 In general, 

--- a/PhotDM.tex
+++ b/PhotDM.tex
@@ -260,7 +260,7 @@ not in digital form. To aid the use of filters information, in particular
 as part of the Photometry Data Model metadata fields, we propose a 
 mechanism for referencing external filter information. Such a 
 \textit{Filter Profile Service} has been implemented in the Spanish Virtual Observatory
-\citep{FPS_AP_ivoa_Note}, \citep{2020sea..confE.182R} and exposes this information so software 
+\citep{2012ivoa.rept.1015R}, \citep{2020sea..confE.182R} and exposes this information so software 
 client applications could discover it. 
 
 The following sections of this document summarize some key points 
@@ -867,7 +867,7 @@ data fields as shown above. See serialization example in section
 \paragraph{PhotometryFilter.transmissionCurve.access}
 If the transmission curve is hooked as an external file, we use the \textit{Access} class 
 defined in the Observation Core Components data model \citep{2017ivoa.spec.0509L} and inherited 
-from the SSA specification \citep{2012ivoatody}.
+from the SSA specification \citep{2012ivoa.spec.0210T}.
 \par
 
 \subparagraph{PhotometryFilter.transmissionCurve.access.reference} 
@@ -1365,7 +1365,7 @@ reference to perform photometric calibration.
 \par
 
 This points to a Spectrum object as defined in the IVOA spectrum data 
-model \citep{mcdowell2012ivoa}. Instead of having the whole spectrum 
+model \citep{2011ivoa.spec.1120M}. Instead of having the whole spectrum 
 attached, we define a link to it as referenceSpectrumURI. 
 The spectrum will be retrieved by invoking the URI. For example:
 \par

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,10 +1,3 @@
-%FPS_AP_ivoa_Note
-@misc{FPS_AP_ivoa_Note,
-    title={Filter Profile Service Access Protocol, Version 1.0, IVOA Note 10 May 2013},
-    author={C.Rodrigo, E. Solano},
-    year={2013},
-    url={https://ivoa.net/documents/Notes/SVOFPSDAL/}
-}
 @INPROCEEDINGS{2020sea..confE.182R,
        author = {{Rodrigo}, C. and {Solano}, E.},
         title = "{The SVO Filter Profile Service}",
@@ -120,15 +113,6 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@misc{2012ivoatody,
-    title={IVOA Recommendation: Simple Spectral Access Protocol Version 1.1},
-    author={Doug Tody and Markus Dolensky and Jonathan McDowell and Francois Bonnarel and Tamas Budavari and Ivo Busko and Alberto Micol and Pedro Osuna and Jesus Salgado and Petr Skoda and Randy Thompson and Frank Valdes and the Data Access Layer working group},
-    year={2012},
-    eprint={1203.5725},
-    archivePrefix={arXiv},
-    primaryClass={astro-ph.IM}
-}
-
 @ARTICLE{1999AJ....118.1406L,
        author = {{Lupton}, Robert H. and {Gunn}, James E. and {Szalay}, Alexander S.},
         title = "{A Modified Magnitude System that Produces Well-Behaved Magnitudes, Colors, and Errors Even for Low Signal-to-Noise Ratio Measurements}",
@@ -161,15 +145,6 @@ archivePrefix = {arXiv},
     publisher= {Bristol: IOP Publishing and London: Nature Publishing},
     adsurl = {https://ui.adsabs.harvard.edu/abs/2001eaa..book.....M},
     adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@misc{mcdowell2012ivoa,
-    title={IVOA Recommendation: Spectrum Data Model 1.1},
-    author={Jonathan McDowell and Doug Tody and Tamas Budavari and Markus Dolensky and Inga Kamp and Kelly McCusker and Pavlos Protopapas and Arnold Rots and Randy Thompson and Frank Valdes and Petr Skoda and Bruno Rino and Sebastien Derriere and Jesus Salgado and Omar Laurino and the IVOA Data Access Layer and Data Model Working Groups},
-    year={2012},
-    eprint={1204.3055},
-    archivePrefix={arXiv},
-    primaryClass={astro-ph.IM}
 }
 
 @ARTICLE{2004AJ....127.3508B,


### PR DESCRIPTION
* paragraph and subparagraph is now formatted section-like and does its
own numbering
* removing global label for lstings (which only gives warnings without
helping any)
* fixing citep usage (that already makes parentheses itself)
* replacing a few local bibliography items with their counterparts from docrepo.bib