### PR TITLE
name-space "dm-mapping" removed everywhere

### DIFF
--- a/serializations/2MASS_Filter_Mapping_Example.xml
+++ b/serializations/2MASS_Filter_Mapping_Example.xml
@@ -1,86 +1,86 @@
 <!-- 2022-03-11 M.Louys, L. Michel
 XML serialization of Photometry Filter expressed as a mapping block in ModelInVotable syntax -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="2MASS" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
     
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_2MASS_H"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_2MASS_H"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_H">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_H">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1024.0" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1024.0" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter reference-->
-  <dm-mapping:REFERENCE dmref="_filter_2MASS_H" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_2MASS_H" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter instance-->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_H">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_H">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="2MASS/2MASS.H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="2MASS H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="2MASS H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="H" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="H" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="16620.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
+  </INSTANCE>
 
   <!-- Transmission Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/2MASS_PhotSys.xml
+++ b/serializations/2MASS_PhotSys.xml
@@ -7,110 +7,110 @@ L.Michel, M.Louys
  -->
  
 <!-- Photometric System 2MASS -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_2MASS_PhotSys">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="2MASS" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="0" />
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_2MASS_PhotSys">
+    <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="2MASS" />
+    <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="0" />
 
 
     <!--  Filter 2MASS.H -->
-    <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter dmid=_2MASS_H_filter">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS H" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS H" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="H" />
+    <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter dmid=_2MASS_H_filter">
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS H" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS H" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="H" />
 
         <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="16620.0" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="16620.0" />
+        </INSTANCE>
 
         <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="18231.020407164" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+            <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
+            <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="18231.020407164" />
+        </INSTANCE>
 
         <!-- Transmision Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
-    </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+            <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+            </INSTANCE>
+        </INSTANCE>
+    </INSTANCE>
 
 <!--  Filter 2MASS.J -->
-    <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_J_filter">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="J" />
+    <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_J_filter">
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS J" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS J" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="J" />
 
         <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="12350.0" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="12350.0" />
+        </INSTANCE>
 
         <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwith" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.extent" dmtype="ivoa:real" value="1624.3190191027" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="10806.470589792" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="14067.974683578" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:Bandwith" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:Bandwith.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.extent" dmtype="ivoa:real" value="1624.3190191027" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="10806.470589792" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="14067.974683578" />
+        </INSTANCE>
 
         <!-- Transmision Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+            <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+            </INSTANCE>
+        </INSTANCE>
 
       
     <!--  Filter 2MASS Ks-->
-    <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_KS_filter">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="Ks" />
+    <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_KS_filter">
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS Ks" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS Ks" />
+        <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="Ks" />
 
         <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="21590.0" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="21590.0" />
+        </INSTANCE>
 
         <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwith" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.extent" dmtype="ivoa:real" value="2618.8695332218" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="19543.692304348" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="23552.400005256" />
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:Bandwith" dmrole="photdm:PhotometryFilter.spectralLocation">
+            <ATTRIBUTE dmrole="photdm:Bandwith.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.extent" dmtype="ivoa:real" value="2618.8695332218" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="19543.692304348" />
+            <ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="23552.400005256" />
+        </INSTANCE>
 
         <!-- Transmision Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
+        <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+            <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+            </INSTANCE>
+        </INSTANCE>
         
-    </dm-mapping:INSTANCE>  <!-- end Photsys 2MASS>
+    </INSTANCE>  <!-- end Photsys 2MASS>

--- a/serializations/exampleXML2MASS.xml
+++ b/serializations/exampleXML2MASS.xml
@@ -1,118 +1,120 @@
-<!-- XML serialization of a PhotSys 2MASS as 3 filters
-L.Michel, M.Louys  -->
+<!-- XML serialization of a PhotSys 2MASS as 3 filters L.Michel, M.Louys -->
 <!-- Photometric System 2MASS -->
 <RESOURCE ID="T9001" type="results">
-    <RESOURCE type="meta">
-	<dm-mapping:VODML xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
-	<dm-mapping:MODEL name="photdm" version="1.1" />
-	<dm-mapping:GLOBALS>
-        <dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_2MASS_PhotSys">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="2MASS" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="0" />
-    <!--  Filter 2MASS.H -->
-        <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter dmid=_2MASS_H_filter">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS H" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS H" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="H" />
-        <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="16620.0" />
-        </dm-mapping:INSTANCE>
+  <RESOURCE type="meta">
+    <VODML xmlns="http://www.ivoa.net/xml/merged-syntax">
+      <MODEL name="photdm" version="1.1" />
+      <GLOBALS>
+        <INSTANCE dmtype="photdm:PhotometricSystem" dmid="_2MASS_PhotSys">
+          <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="2MASS" />
+          <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="0" />
+          <!-- Filter 2MASS.H -->
+          <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter dmid=_2MASS_H_filter">
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS H" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS H" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="H" />
+            <!-- Spectral Location -->
+            <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="16620.0" />
+            </INSTANCE>
 
-        <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
-        </dm-mapping:INSTANCE>
+            <!-- Band width -->
+            <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
+            </INSTANCE>
 
-        <!-- Transmision Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
-    </dm-mapping:INSTANCE>  <!-- end Filter H -->
+            <!-- Transmision Curve -->
+            <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+              <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+                  value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+              </INSTANCE>
+            </INSTANCE>
+          </INSTANCE>  <!-- end Filter H -->
 
-<!--  Filter 2MASS.J -->
-    <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_J_filter">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS J" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="J" />
+          <!-- Filter 2MASS.J -->
+          <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_J_filter">
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS J" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS J" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="J" />
 
-        <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="12350.0" />
-        </dm-mapping:INSTANCE>
+            <!-- Spectral Location -->
+            <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="12350.0" />
+            </INSTANCE>
 
-        <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1624.3190191027" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="10806.470589792" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="14067.974683578" />
-        </dm-mapping:INSTANCE>
+            <!-- Band width -->
+            <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1624.3190191027" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="10806.470589792" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="14067.974683578" />
+            </INSTANCE>
 
-        <!-- Transmission Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
- </dm-mapping:INSTANCE> <!-- end Filter J -->
-      
-    <!--  Filter 2MASS Ks-->
-    <dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_KS_filter">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS Ks" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="Ks" />
+            <!-- Transmission Curve -->
+            <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+              <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+                  value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+              </INSTANCE>
+            </INSTANCE>
+          </INSTANCE> <!-- end Filter J -->
 
-        <!-- Spectral Location -->
-        <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="21590.0" />
-        </dm-mapping:INSTANCE>
+          <!-- Filter 2MASS Ks -->
+          <INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter" dmid="_2MASS_KS_filter">
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string" value="ivo://svo/fps" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="2MASS Ks" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="2MASS Ks" />
+            <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="Ks" />
 
-        <!-- Band width -->
-        <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2618.8695332218" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="19543.692304348" />
-            <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="23552.400005256" />
-        </dm-mapping:INSTANCE>
+            <!-- Spectral Location -->
+            <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="21590.0" />
+            </INSTANCE>
 
-        <!-- Transmission Curve -->
-        <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-            <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-                <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-            </dm-mapping:INSTANCE>
-        </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE> <!-- end Filter  Ks-->
-    
-</dm-mapping:INSTANCE>  <!-- end Photsys 2MASS -->
+            <!-- Band width -->
+            <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+              <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2618.8695332218" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="19543.692304348" />
+              <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="23552.400005256" />
+            </INSTANCE>
 
-</dm_mapping:GLOBALS >
-</dm_mapping:VODML>
- </RESOURCE>
+            <!-- Transmission Curve -->
+            <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+              <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+                <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+                  value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
+                <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+                <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+              </INSTANCE>
+            </INSTANCE>
+          </INSTANCE> <!-- end Filter Ks -->
+
+        </INSTANCE>  <!-- end Photsys 2MASS -->
+
+      </GLOBALS>
+    </VODML>
+  </RESOURCE>
 </RESOURCE>

--- a/serializations/photdm.2MASS.2MASS.H.xml
+++ b/serializations/photdm.2MASS.2MASS.H.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="2MASS" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_2MASS_H"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_2MASS_H"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_H">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_H">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.H/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1024.0" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1024.0" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_2MASS_H" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_2MASS_H" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_H">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_H">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="2MASS/2MASS.H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="2MASS H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="2MASS H" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="H" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="H" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="16620.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2509.4034987068" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="14787.378640179" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="18231.020407164" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.H/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.2MASS.2MASS.J.xml
+++ b/serializations/photdm.2MASS.2MASS.J.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="2MASS" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_2MASS_J"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_2MASS_J"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_J">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_J">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.J/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1594.0" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="1594.0" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_2MASS_J" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_2MASS_J" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_J">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_J">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="2MASS/2MASS.J" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="2MASS J" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="2MASS J" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="J" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="J" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="12350.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1624.3190191027" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="10806.470589792" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="14067.974683578" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1624.3190191027" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="10806.470589792" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="14067.974683578" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.J/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.2MASS.2MASS.Ks.xml
+++ b/serializations/photdm.2MASS.2MASS.Ks.xml
@@ -1,83 +1,83 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_2MASS">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="2MASS" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_2MASS_Ks"/>
-  </dm-mapping:COLLECTION>
-</dm-mapping:INSTANCE>
+    <REFERENCE dmref="_filter_2MASS_Ks"/>
+  </COLLECTION>
+</INSTANCE>
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_Ks">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_2MASS_Ks">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="2MASS/2MASS.Ks/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="666.8" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="666.8" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_2MASS_Ks" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_2MASS_Ks" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_Ks">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_2MASS_Ks">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsIdentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="2MASS/2MASS.Ks" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="2MASS Ks" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="2MASS Ks" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="Ks" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandName" dmtype="ivoa:string" value="Ks" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="21590.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2618.8695332218" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="19543.692304348" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="23552.400005256" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="2618.8695332218" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="19543.692304348" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="23552.400005256" />
+  </INSTANCE>
 
   <!-- Transmission Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=2MASS/2MASS.Ks/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.GAIA.GAIA2.G.xml
+++ b/serializations/photdm.GAIA.GAIA2.G.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_GAIA">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_GAIA">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="GAIA" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_GAIA2_G"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_GAIA2_G"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_GAIA2_G">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="GAIA/GAIA2.G/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_GAIA2_G">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="GAIA/GAIA2.G/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="3296.201" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="3296.201" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_GAIA2_G" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_GAIA2_G" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_GAIA2_G">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_GAIA2_G">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="GAIA/GAIA2.G" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="GAIA G filter, DR2" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="GAIA G filter, DR2" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="6230.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="4182.964383547" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="3306.6039005948" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="10450.650159395" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="4182.964383547" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="3306.6039005948" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="10450.650159395" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=GAIA/GAIA2.G/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwith.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=GAIA/GAIA2.G/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.WISE.WISE.W1.xml
+++ b/serializations/photdm.WISE.WISE.W1.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="WISE" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_WISE_W1"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_WISE_W1"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W1">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W1/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W1">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W1/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="309.54" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="309.54" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_WISE_W1" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_WISE_W1" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W1">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W1">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="WISE/WISE.W1" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="WISE W1 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="WISE W1 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="33526.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="6626.4186524258" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="27540.970745309" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="38723.877229677" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="6626.4186524258" />
+    <ATTRIBUTE dmrole="photdm:Bandwith.start" dmtype="ivoa:real" value="27540.970745309" />
+    <ATTRIBUTE dmrole="photdm:Bandwith.stop" dmtype="ivoa:real" value="38723.877229677" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W1/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W1/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.WISE.WISE.W2.xml
+++ b/serializations/photdm.WISE.WISE.W2.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="WISE" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_WISE_W2"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_WISE_W2"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W2">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W2/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W2">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W2/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="171.787" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="171.787" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_WISE_W2" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_WISE_W2" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W2">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W2">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="WISE/WISE.W2" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="WISE W2 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="WISE W2 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="46028.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10422.660627836" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="39633.264098975" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="53413.603102133" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10422.660627836" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="39633.264098975" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="53413.603102133" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W2/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W2/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.WISE.WISE.W3.xml
+++ b/serializations/photdm.WISE.WISE.W3.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="WISE" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_WISE_W3"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_WISE_W3"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W3">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W3/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W3">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W3/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="31.674" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="31.674" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_WISE_W3" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_WISE_W3" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W3">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W3">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="WISE/WISE.W3" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="WISE W3 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="WISE W3 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="115608.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="55055.705185818" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="74430.442564269" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="172613.42742331" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="55055.705185818" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="74430.442564269" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="172613.42742331" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W3/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W3/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.WISE.WISE.W4.xml
+++ b/serializations/photdm.WISE.WISE.W4.xml
@@ -1,85 +1,85 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_sys_WISE">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string"
     value="WISE" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer"
     value="0" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter_WISE_W4"/>
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter_WISE_W4"/>
+  </COLLECTION>
     
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W4">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W4/Vega" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_cal_WISE_W4">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="WISE/WISE.W4/Vega" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem"
       value="Vega" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="http://svo2.cab.inta-csic.es/theory/fps/morefiles/vega.dat" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Zero Point -->
-  <dm-mapping:INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
+  <INSTANCE dmtype="photdm:PogsonZeroPoint" dmrole="photdm:PhotCal.zeroPoint">
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.type" dmtype="ivoa:string" value="Pogson" />
+    <ATTRIBUTE dmrole="photdm:ZeroPoint.referenceMagnitudeValue" dmtype="ivoa:real"
       value="0" />
 
-    <dm-mapping:INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
+    <INSTANCE dmtype="photdm:Flux" dmrole="photdm:ZeroPoint.flux">
+      <ATTRIBUTE dmrole="photdm:Flux.ucd" dmtype="ivoa:UCD" value="phot.flux;meta.modelled" />
+      <ATTRIBUTE dmrole="photdm:Flux.unitexpression" dmtype="ivoa:Unit"
         value="Jy" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="8.363" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Flux.value" dmtype="ivoa:real" value="8.363" />
+    </INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter_WISE_W4" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter_WISE_W4" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W4">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter_WISE_W4">
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="WISE/WISE.W4" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string"
     value="WISE W4 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string"
     value="WISE W4 filter" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD"
       value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit"
       value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real"
       value="220883.0" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="41016.829183507" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="195200.83360398" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="279107.24275724" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="Angstrom" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="41016.829183507" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="195200.83360398" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="279107.24275724" />
+  </INSTANCE>
 
   <!-- Transmision Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W4/Vega" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI" value="http://svo2.cab.inta-csic.es/theory/fps/fps.php?PhotCalID=WISE/WISE.W4/Vega" />
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="VOTable" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.XMMSL2.XMMSL2.EB6.xml
+++ b/serializations/photdm.XMMSL2.XMMSL2.EB6.xml
@@ -1,65 +1,65 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB6" />
-  </dm-mapping:COLLECTION>
+    <REFERENCE dmref="_filter__XMMSL2_EB6" />
+  </COLLECTION>
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_XMMSL2_EB6">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB6" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_XMMSL2_EB6">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB6" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB6" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter__XMMSL2_EB6" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter__XMMSL2_EB6"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmid="_filter__XMMSL2_EB6"
   dmrole="photdm:PhotCal.photometryFilter">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="XMMSL2/XMMSL2.EB6" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB6" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Soft" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB7" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB6" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Soft" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB7" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="1.1" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="1.1" />
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1.8" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="0.2" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="2.0" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="1.8" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="0.2" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="2.0" />
+  </INSTANCE>
 
   <!-- Transmission Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
         value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.XMMSL2.XMMSL2.EB7.xml
+++ b/serializations/photdm.XMMSL2.XMMSL2.EB7.xml
@@ -1,64 +1,64 @@
 <!-- XML serialization of Photometry Filter -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
+  <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB7" />
-  </dm-mapping:COLLECTION>
-</dm-mapping:INSTANCE>
+    <REFERENCE dmref="_filter__XMMSL2_EB7" />
+  </COLLECTION>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal" dmid="_XMMSL2_EB7">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB7" />
+<INSTANCE dmtype="photdm:PhotCal" dmid="_XMMSL2_EB7">
+  <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB7" />
   <!-- Magnitude System -->
-  <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
+  <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
+    <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI"
       value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-  </dm-mapping:INSTANCE>
+  </INSTANCE>
 
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB7" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter__XMMSL2_EB7" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter"
   dmid="_filter__XMMSL2_EB7">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="XMMSL2/XMMSL2.EB7" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB7" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Hard" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB7" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB7" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Hard" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB7" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="7.0" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="7.0" />
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10.0" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="2.0" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="12.0" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10.0" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="2.0" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="12.0" />
+  </INSTANCE>
 
   <!-- Transmission Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
         value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
-</dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
+    </INSTANCE>
+  </INSTANCE>
+</INSTANCE>

--- a/serializations/photdm.XMMSL2.XMMSL2.EB8.xml
+++ b/serializations/photdm.XMMSL2.XMMSL2.EB8.xml
@@ -4,67 +4,67 @@ XML serialization of Photometry Filter
 
  -->
 <!-- Photometric System -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
-  <dm-mapping:COLLECTION dmrole="photdm:PhotCal.photometryFilter">
+<INSTANCE dmtype="photdm:PhotometricSystem" dmid="_XMMSL2">
+    <ATTRIBUTE dmrole="photdm:PhotometricSystem.description" dmtype="ivoa:string" value="XMMSL2" />
+    <ATTRIBUTE dmrole="photdm:PhotometricSystem.detectorType" dmtype="ivoa:integer" value="1" />
+  <COLLECTION dmrole="photdm:PhotCal.photometryFilter">
     <!-- Others filter references can be added here -->
-    <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB8" />
-  </dm-mapping:COLLECTION>
-</dm-mapping:INSTANCE>
+    <REFERENCE dmref="_filter__XMMSL2_EB8" />
+  </COLLECTION>
+</INSTANCE>
 
 
 <!-- Photometric Calibration -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotCal"  dmid="_XMMSL2_EB8">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB8" />
+<INSTANCE dmtype="photdm:PhotCal"  dmid="_XMMSL2_EB8">
+    <ATTRIBUTE dmrole="photdm:PhotCal.identifier" dmtype="ivoa:string" value="XMMSL2/XMMSL2.EB8" />
     <!-- Magnitude System -->
-    <dm-mapping:INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
-        <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
-        <dm-mapping:ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI" 
+    <INSTANCE dmtype="photdm:MagnitudeSystem" dmrole="photdm:PhotCal.magnitudeSystem">
+        <ATTRIBUTE dmrole="photdm:MagnitudeSystem.type" dmtype="photdm:TypeOfMagSystem" value="XMM" />
+        <ATTRIBUTE dmrole="photdm:MagnitudeSystem.referenceSpectrum" dmtype="ivoa:anyURI" 
                    value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-    </dm-mapping:INSTANCE>
+    </INSTANCE>
         
     <!--  Filter -->
   <!-- Filter -->
-  <dm-mapping:REFERENCE dmref="_filter__XMMSL2_EB8" dmrole="photdm:PhotCal.photometryFilter" />
+  <REFERENCE dmref="_filter__XMMSL2_EB8" dmrole="photdm:PhotCal.photometryFilter" />
 
-</dm-mapping:INSTANCE>
+</INSTANCE>
 
 <!-- Filter -->
-<dm-mapping:INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter"
+<INSTANCE dmtype="photdm:PhotometryFilter" dmrole="photdm:PhotCal.photometryFilter"
   dmid="_filter__XMMSL2_EB8">
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.fpsidentifier" dmtype="ivoa:string"
     value="ivo://svo/fps" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.identifier" dmtype="ivoa:string"
     value="XMMSL2/XMMSL2.EB8" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB8" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Hard" />
-  <dm-mapping:ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB8" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.name" dmtype="ivoa:string" value="XMMSL2 EB8" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.description" dmtype="ivoa:string" value="Hard" />
+  <ATTRIBUTE dmrole="photdm:PhotometryFilter.bandname" dmtype="ivoa:string" value="EB8" />
 
   <!-- Spectral Location -->
-  <dm-mapping:INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="7.0" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:SpectralLocation" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.ucd" dmtype="ivoa:UCD" value="em.wl.effective" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:SpectralLocation.value" dmtype="ivoa:real" value="7.0" />
+  </INSTANCE>
 
   <!-- Band width -->
-  <dm-mapping:INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10.0" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="2.0" />
-    <dm-mapping:ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="12.0" />
-  </dm-mapping:INSTANCE>
+  <INSTANCE dmtype="photdm:Bandwidth" dmrole="photdm:PhotometryFilter.spectralLocation">
+    <ATTRIBUTE dmrole="photdm:Bandwidth.ucd" dmtype="ivoa:UCD" value="instr.bandwidth;stat.fwhm" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.unitexpression" dmtype="ivoa:Unit" value="keV" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.extent" dmtype="ivoa:real" value="10.0" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.start" dmtype="ivoa:real" value="2.0" />
+    <ATTRIBUTE dmrole="photdm:Bandwidth.stop" dmtype="ivoa:real" value="12.0" />
+  </INSTANCE>
 
   <!-- Transmission Curve -->
-  <dm-mapping:INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
-    <dm-mapping:INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
+  <INSTANCE dmtype="photdm:TransmissionCurve" dmrole="photdm:Bandwidth.transmissionCurve">
+    <INSTANCE dmtype="photdm:Access" dmrole="photdm:TransmissionCurve.access">
+      <ATTRIBUTE dmrole="photdm:Access.reference" dmtype="ivoa:anyURI"
         value="https://www.cosmos.esa.int/web/xmm-newton/xmmsl2-ug" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
-      <dm-mapping:ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
-    </dm-mapping:INSTANCE>
-  </dm-mapping:INSTANCE>
+      <ATTRIBUTE dmrole="photdm:Access.size" dmtype="ivoa:integer" value="-1" />
+      <ATTRIBUTE dmrole="photdm:Access.format" dmtype="ivoa:string" value="HTML" />
+    </INSTANCE>
+  </INSTANCE>
 
 


### PR DESCRIPTION
The `dm-mapping`  name space has been removed from all XML snippets. 
Although still being in the mapping [draft](https://github.com/ivoa-std/ModelInstanceInVot), this name space will be removed from the specification.
This small discrepancy between PhotDM and MIVOT is harmless since MIVOT is still a draft.