### PR TITLE
Update 2MASS_PhotSys.xml

### DIFF
--- a/serializations/2MASS_PhotSys.xml
+++ b/serializations/2MASS_PhotSys.xml
@@ -1,8 +1,5 @@
-<mapping >
-<!-- PhotSys 2MASS -->
-<!-- 
-
-XML serialization of a PhotSys 2MASS : 3 filters
+<!-- PhotSys 2MASS MIVOT syntax -->
+<!-- XML serialization of a PhotSys 2MASS : 3 filters 
 L.Michel, M.Louys 
  -->
  


### PR DESCRIPTION
typo corrections for the mapping block for the 3 filters of 2MASS. 